### PR TITLE
Fix Makefile command indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,24 +6,24 @@ PY=$(VENV)/bin/python
 .PHONY: setup lint test run web bench clean
 
 setup:
-$(PYTHON) -m venv $(VENV)
-$(PIP) install --upgrade pip
-$(PIP) install -e .[dev]
+	$(PYTHON) -m venv $(VENV)
+	$(PIP) install --upgrade pip
+	$(PIP) install -e .[dev]
 
 lint:
-$(PY) -m pyflakes sudoku tests
+	$(PY) -m pyflakes sudoku tests
 
 test:
-$(PY) -m pytest
+	$(PY) -m pytest
 
 run:
-$(PY) -m sudoku.cli --file puzzles/easy.txt --format grid
+	$(PY) -m sudoku.cli --file puzzles/easy.txt --format grid
 
 web:
-FLASK_APP=sudoku.web $(PY) -m flask run --reload --port 5000
+	FLASK_APP=sudoku.web $(PY) -m flask run --reload --port 5000
 
 bench:
-$(PY) -m sudoku.cli --bench puzzles/hard.txt
+	$(PY) -m sudoku.cli --bench puzzles/hard.txt
 
 clean:
-rm -rf $(VENV)
+	rm -rf $(VENV)


### PR DESCRIPTION
## Summary
- replace the command indentation in the Makefile recipes with tabs so GNU Make parses them correctly

## Testing
- ⚠️ `make setup` *(fails: editable install cannot be built because setuptools finds multiple top-level packages in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d50a3c8184832babc09da5b0430161