### PR TITLE
Fix package discovery configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ Homepage = "https://example.com"
 requires = ["setuptools>=65", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.packages.find]
+include = ["sudoku"]
+
 [tool.pytest.ini_options]
 addopts = "-ra"
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- configure setuptools to only include the sudoku package to fix editable installs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d50f729950832b8f84a730baaad7d4