### PR TITLE
Ensure tests can import sudoku package

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- add a pytest conftest to prepend the repository root to `sys.path`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d587d59620832b8913d427ccfb4b38